### PR TITLE
CARF-219: Create FE/BE connection for Register With ID endpoint (Individuals)

### DIFF
--- a/app/uk/gov/hmrc/carfregistration/Module.scala
+++ b/app/uk/gov/hmrc/carfregistration/Module.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.carfregistration
 
 import com.google.inject.AbstractModule
 import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.controllers.actions.{AuthAction, AuthActionImpl}
+import uk.gov.hmrc.carfregistration.controllers.actions.{AuthAction, DefaultAuthAction}
 
 import java.time.Clock
 
@@ -26,7 +26,7 @@ class Module extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
+    bind(classOf[AuthAction]).to(classOf[DefaultAuthAction]).asEagerSingleton()
     bind(classOf[AppConfig]).asEagerSingleton()
   }
 }

--- a/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.carfregistration.config
 
-import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class AppConfig @Inject() (config: Configuration):

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegisterController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegisterController.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.controllers
+
+import com.google.inject.Inject
+import play.api.Logging
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, ControllerComponents}
+import uk.gov.hmrc.carfregistration.controllers.actions.AuthAction
+import uk.gov.hmrc.carfregistration.models.requests.RegisterIndividualWithIdRequest
+import uk.gov.hmrc.carfregistration.services.RegistrationService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class RegisterController @Inject() (
+    cc: ControllerComponents,
+    authorise: AuthAction,
+    service: RegistrationService
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with Logging {
+
+  def registerIndividualWithId(): Action[JsValue] = authorise(parse.json).async { implicit request =>
+    request.body
+      .validate[RegisterIndividualWithIdRequest]
+      .fold(
+        invalid = failure =>
+          println("AAAAAAAA")
+          println(failure)
+          Future.successful(BadRequest(""))
+        ,
+        valid = sub =>
+          println("BBBBBBBB")
+          println(sub)
+          Future.successful(Ok(Json.toJson(service.createRegisterIndividualResponse())))
+      )
+  }
+
+}

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegisterController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegisterController.scala
@@ -47,7 +47,7 @@ class RegisterController @Inject() (
         valid = sub =>
           println("BBBBBBBB")
           println(sub)
-          Future.successful(Ok(Json.toJson(service.createRegisterIndividualResponse())))
+          Future.successful(service.returnResponse(sub.IDNumber))
       )
   }
 

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -37,9 +37,9 @@ class RegistrationController @Inject() (
 
   def registerIndividualWithId(): Action[JsValue] = authorise(parse.json).async { implicit request =>
     withJsonBody[RegisterIndividualWithIdRequest] { request =>
-      println(s"%%% LOOK HERE (Request) %%% \n-> $request")
+      logger.info(s"%%% LOOK HERE (Request) %%% \n-> $request")
       val response = service.returnResponse(request.IDNumber)
-      println(s"%%% LOOK HERE (Response) %%% \n-> $request")
+      logger.info(s"%%% LOOK HERE (Response) %%% \n-> $request")
       Future.successful(response)
     }
   }

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.carfregistration.controllers
 
 import com.google.inject.Inject
 import play.api.Logging
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.carfregistration.controllers.actions.AuthAction
 import uk.gov.hmrc.carfregistration.models.requests.RegisterIndividualWithIdRequest

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -39,7 +39,7 @@ class RegistrationController @Inject() (
     withJsonBody[RegisterIndividualWithIdRequest] { request =>
       logger.info(s"%%% LOOK HERE (Request) %%% \n-> $request")
       val response = service.returnResponse(request.IDNumber)
-      logger.info(s"%%% LOOK HERE (Response) %%% \n-> $request")
+      logger.info(s"%%% LOOK HERE (Response) %%% \n-> $response")
       Future.successful(response)
     }
   }

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class RegisterController @Inject() (
+class RegistrationController @Inject() (
     cc: ControllerComponents,
     authorise: AuthAction,
     service: RegistrationService
@@ -36,19 +36,12 @@ class RegisterController @Inject() (
     with Logging {
 
   def registerIndividualWithId(): Action[JsValue] = authorise(parse.json).async { implicit request =>
-    request.body
-      .validate[RegisterIndividualWithIdRequest]
-      .fold(
-        invalid = failure =>
-          println("AAAAAAAA")
-          println(failure)
-          Future.successful(BadRequest(""))
-        ,
-        valid = sub =>
-          println("BBBBBBBB")
-          println(sub)
-          Future.successful(service.returnResponse(sub.IDNumber))
-      )
+    withJsonBody[RegisterIndividualWithIdRequest] { request =>
+      println(s"%%% LOOK HERE (Request) %%% \n-> $request")
+      val response = service.returnResponse(request.IDNumber)
+      println(s"%%% LOOK HERE (Response) %%% \n-> $request")
+      Future.successful(response)
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/carfregistration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/actions/AuthAction.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.controllers.actions
+
+import com.google.inject.{ImplementedBy, Inject}
+import play.api.http.Status.UNAUTHORIZED
+import play.api.mvc.Results.Status
+import play.api.mvc.*
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual, Organisation}
+import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole}
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.auth.core.*
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthActionImpl @Inject() (
+    override val authConnector: AuthConnector,
+    val parser: BodyParsers.Default
+)(implicit val executionContext: ExecutionContext)
+    extends AuthAction
+    with AuthorisedFunctions {
+
+  override def invokeBlock[A](
+      request: Request[A],
+      block: Request[A] => Future[Result]
+  ): Future[Result] = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+
+    authorised(AuthProviders(GovernmentGateway) and ConfidenceLevel.L50)
+      .retrieve(
+        affinityGroup and credentialRole
+      ) { case userAffinityGroup ~ userCredentialRole =>
+        if (isPermittedUserType(userAffinityGroup, userCredentialRole)) {
+          block(request)
+        } else Future.successful(Status(UNAUTHORIZED))
+      }
+      .recover {
+        case _: NoActiveSession        => Status(UNAUTHORIZED)
+        case _: AuthorisationException => Status(UNAUTHORIZED)
+      }
+  }
+
+  def isPermittedUserType(
+      affinityGroup: Option[AffinityGroup],
+      credentialRole: Option[CredentialRole]
+  ): Boolean =
+    affinityGroup match {
+      case Some(Organisation) | Some(Individual) =>
+        credentialRole.fold(false)(cr => cr == User)
+      case _                                     => false
+    }
+
+}
+
+@ImplementedBy(classOf[AuthActionImpl])
+trait AuthAction extends ActionBuilder[Request, AnyContent] with ActionFunction[Request, Request]

--- a/app/uk/gov/hmrc/carfregistration/models/Address.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/Address.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.carfregistration
+package uk.gov.hmrc.carfregistration.models
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.controllers.actions.{AuthAction, AuthActionImpl}
+import play.api.libs.json.{Json, OFormat}
 
-import java.time.Clock
+case class Address(
+    addressLine1: String,
+    addressLine2: Option[String],
+    addressLine3: Option[String],
+    addressLine4: Option[String],
+    postalCode: Option[String],
+    countryCode: String
+)
 
-class Module extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
-    bind(classOf[AppConfig]).asEagerSingleton()
-  }
+object Address {
+  implicit val format: OFormat[Address] = Json.format[Address]
 }

--- a/app/uk/gov/hmrc/carfregistration/models/requests/AuthenticatedRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/AuthenticatedRequest.scala
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.carfregistration.controllers
+package uk.gov.hmrc.carfregistration.models.requests
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.mockito.MockitoSugar.mock
-import play.api.mvc.ControllerComponents
+import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.http.SessionId
 
-class CarfControllerSpec extends AnyWordSpec with Matchers {
-
-  val TestCC         = mock[ControllerComponents]
-  val TestController = new CarfController(TestCC)
-
-  "carf controller getDetails"     should:
-    "return 5" in:
-      TestController.getDetails mustEqual 5
-}
+case class AuthenticatedRequest[A](
+    private val request: Request[A],
+    internalId: String,
+    sessionId: SessionId,
+    affinityGroup: AffinityGroup
+) extends WrappedRequest[A](request)

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RegisterIndividualWithIdRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RegisterIndividualWithIdRequest.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.carfregistration
+package uk.gov.hmrc.carfregistration.models.requests
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.controllers.actions.{AuthAction, AuthActionImpl}
+import play.api.libs.json.{Json, OFormat}
 
-import java.time.Clock
+case class RegisterIndividualWithIdRequest(
+    requiresNameMatch: Boolean,
+    IDNumber: String,
+    IDType: String,
+    dateOfBirth: String,
+    firstName: String,
+    lastName: String
+)
 
-class Module extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
-    bind(classOf[AppConfig]).asEagerSingleton()
-  }
+object RegisterIndividualWithIdRequest {
+  implicit val format: OFormat[RegisterIndividualWithIdRequest] = Json.format[RegisterIndividualWithIdRequest]
 }

--- a/app/uk/gov/hmrc/carfregistration/models/responses/RegisterIndividualWithIdResponse.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/responses/RegisterIndividualWithIdResponse.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.carfregistration
+package uk.gov.hmrc.carfregistration.models.responses
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.controllers.actions.{AuthAction, AuthActionImpl}
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.carfregistration.models.Address
 
-import java.time.Clock
+case class RegisterIndividualWithIdResponse(
+    safeId: String,
+    firstName: String,
+    lastName: String,
+    middleName: Option[String],
+    address: Address
+)
 
-class Module extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
-    bind(classOf[AppConfig]).asEagerSingleton()
-  }
+object RegisterIndividualWithIdResponse {
+  implicit val format: OFormat[RegisterIndividualWithIdResponse] = Json.format[RegisterIndividualWithIdResponse]
 }

--- a/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.services
+
+import uk.gov.hmrc.carfregistration.models.Address
+import uk.gov.hmrc.carfregistration.models.responses.RegisterIndividualWithIdResponse
+
+import javax.inject.Inject
+
+class RegistrationService @Inject() () {
+
+  def createRegisterIndividualResponse(): RegisterIndividualWithIdResponse =
+    RegisterIndividualWithIdResponse(
+      safeId = "test-safe-id",
+      firstName = "timmy",
+      lastName = "timmy",
+      middleName = Some("hi"),
+      address = Address(
+        addressLine1 = "2 High Street",
+        addressLine2 = Some("Birmingham"),
+        addressLine3 = None,
+        addressLine4 = None,
+        postalCode = Some("B23 2AZ"),
+        countryCode = "GB"
+      )
+    )
+}

--- a/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
@@ -16,6 +16,9 @@
 
 package uk.gov.hmrc.carfregistration.services
 
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.mvc.Results.{InternalServerError, NotFound, Ok}
 import uk.gov.hmrc.carfregistration.models.Address
 import uk.gov.hmrc.carfregistration.models.responses.RegisterIndividualWithIdResponse
 
@@ -23,18 +26,44 @@ import javax.inject.Inject
 
 class RegistrationService @Inject() () {
 
-  def createRegisterIndividualResponse(): RegisterIndividualWithIdResponse =
+  def returnResponse(nino: String): Result = {
+    println("KKKKKKKKKK " + nino)
+    nino.take(1) match {
+      case "9" => InternalServerError("Unexpected error")
+      case "8" => NotFound("Individual user could not be matched")
+      case "7" => Ok(Json.toJson(createEmptyIndividualResponse()))
+      case _   => Ok(Json.toJson(createFullIndividualResponse()))
+    }
+  }
+
+  def createFullIndividualResponse(): RegisterIndividualWithIdResponse =
     RegisterIndividualWithIdResponse(
       safeId = "test-safe-id",
-      firstName = "timmy",
-      lastName = "timmy",
-      middleName = Some("hi"),
+      firstName = "Timmy",
+      lastName = "Timmmy",
+      middleName = Some("Timmy?"),
       address = Address(
         addressLine1 = "2 High Street",
         addressLine2 = Some("Birmingham"),
+        addressLine3 = Some("Nowhereshire"),
+        addressLine4 = Some("Down the road"),
+        postalCode = Some("B23 2AZ"),
+        countryCode = "GB"
+      )
+    )
+
+  def createEmptyIndividualResponse(): RegisterIndividualWithIdResponse =
+    RegisterIndividualWithIdResponse(
+      safeId = "test-safe-id",
+      firstName = "Test",
+      lastName = "Userson",
+      middleName = None,
+      address = Address(
+        addressLine1 = "2 High Street",
+        addressLine2 = None,
         addressLine3 = None,
         addressLine4 = None,
-        postalCode = Some("B23 2AZ"),
+        postalCode = None,
         countryCode = "GB"
       )
     )

--- a/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
@@ -26,15 +26,13 @@ import javax.inject.Inject
 
 class RegistrationService @Inject() () {
 
-  def returnResponse(nino: String): Result = {
-    println("KKKKKKKKKK " + nino)
+  def returnResponse(nino: String): Result =
     nino.take(1) match {
       case "9" => InternalServerError("Unexpected error")
       case "8" => NotFound("Individual user could not be matched")
       case "7" => Ok(Json.toJson(createEmptyIndividualResponse()))
       case _   => Ok(Json.toJson(createFullIndividualResponse()))
     }
-  }
 
   def createFullIndividualResponse(): RegisterIndividualWithIdResponse =
     RegisterIndividualWithIdResponse(

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val microservice = Project("carf-registration", file("."))
     // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
     // suppress warnings in generated routes files
     scalacOptions += "-Wconf:src=routes/.*:s",
-    scalafmtOnCompile := true
+    scalafmtOnCompile := true,
+    PlayKeys.playDefaultPort := 17001
   )
   .settings(CodeCoverageSettings.settings: _*)
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,1 +1,3 @@
 # microservice specific routes
+
+POST         /individual/nino                uk.gov.hmrc.carfregistration.controllers.RegisterController.registerIndividualWithId()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-POST         /individual/nino                uk.gov.hmrc.carfregistration.controllers.RegisterController.registerIndividualWithId()
+POST         /individual/nino                uk.gov.hmrc.carfregistration.controllers.RegistrationController.registerIndividualWithId()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,6 +22,9 @@ appName = carf-registration
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
+# From CRS FATCA
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
+
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.carfregistration.Module"
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,3 +1,3 @@
 # Add all the application routes to the app.routes file
-->         /carf-registration              app.Routes
-->         /                          health.Routes
+->        /carf-registration        app.Routes
+->        /                         health.Routes

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,15 +4,14 @@ import sbt._
 object AppDependencies {
 
   private val bootstrapVersion = "10.2.0"
-  
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion
+    "uk.gov.hmrc"   %% "bootstrap-backend-play-30" % bootstrapVersion,
+    "org.typelevel" %% "cats-core"                 % "2.13.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapVersion            % Test,
-    
+    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test
   )
 
   val it = Seq.empty

--- a/test/actions/FakeAuthAction.scala
+++ b/test/actions/FakeAuthAction.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package actions
+
+import play.api.mvc.{PlayBodyParsers, Request, Result}
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.carfregistration.controllers.actions.AuthAction
+import uk.gov.hmrc.http.SessionId
+import uk.gov.hmrc.carfregistration.models.requests.AuthenticatedRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeAuthAction(
+    bodyParsers: PlayBodyParsers,
+    testCredId: String = "cred-123",
+    testAffinityGroup: AffinityGroup = Organisation,
+    testNino: Option[String] = Some("AB123456C")
+) extends AuthAction {
+
+  override def parser = bodyParsers.default
+
+  override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] =
+    block(
+      AuthenticatedRequest(
+        request,
+        internalId = "internalId-123",
+        sessionId = SessionId("sessionId-123"),
+        affinityGroup = testAffinityGroup
+      )
+    )
+
+  override protected def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+}

--- a/test/actions/FakeAuthAction.scala
+++ b/test/actions/FakeAuthAction.scala
@@ -20,8 +20,8 @@ import play.api.mvc.{PlayBodyParsers, Request, Result}
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
 import uk.gov.hmrc.carfregistration.controllers.actions.AuthAction
-import uk.gov.hmrc.http.SessionId
 import uk.gov.hmrc.carfregistration.models.requests.AuthenticatedRequest
+import uk.gov.hmrc.http.SessionId
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,17 +17,18 @@
 package base
 
 import actions.FakeAuthAction
-import org.scalatest.{BeforeAndAfterEach, OptionValues, TestSuite, TryValues}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatest.{BeforeAndAfterEach, OptionValues, TestSuite, TryValues}
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.{BaseOneAppPerSuite, FakeApplicationFactory}
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, PlayBodyParsers}
-import play.api.test.{DefaultAwaitTimeout, FakeHeaders, FakeRequest}
 import play.api.test.Helpers.stubControllerComponents
+import play.api.test.{DefaultAwaitTimeout, FakeHeaders, FakeRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
@@ -43,7 +44,8 @@ trait SpecBase
     with BeforeAndAfterEach
     with TestSuite
     with FakeApplicationFactory
-    with BaseOneAppPerSuite {
+    with BaseOneAppPerSuite
+    with MockitoSugar {
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import actions.FakeAuthAction
+import org.scalatest.{BeforeAndAfterEach, OptionValues, TestSuite, TryValues}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.play.{BaseOneAppPerSuite, FakeApplicationFactory}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsValue
+import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, PlayBodyParsers}
+import play.api.test.{DefaultAwaitTimeout, FakeHeaders, FakeRequest}
+import play.api.test.Helpers.stubControllerComponents
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+
+trait SpecBase
+    extends AnyFreeSpec
+    with Matchers
+    with TryValues
+    with DefaultAwaitTimeout
+    with OptionValues
+    with ScalaFutures
+    with IntegrationPatience
+    with BeforeAndAfterEach
+    with TestSuite
+    with FakeApplicationFactory
+    with BaseOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .build()
+
+  val cc: ControllerComponents                         = stubControllerComponents()
+  val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  val bodyParsers: PlayBodyParsers                     = app.injector.instanceOf[PlayBodyParsers]
+  val fakeAuthAction                                   = new FakeAuthAction(bodyParsers)
+
+  def fakeRequestWithJsonBody(json: JsValue): FakeRequest[JsValue] = FakeRequest("", "/", FakeHeaders(), json)
+
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+}

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -17,5 +17,70 @@
 package controllers
 
 import base.SpecBase
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Results.{BadRequest, Ok}
+import uk.gov.hmrc.carfregistration.controllers.RegistrationController
+import uk.gov.hmrc.carfregistration.models.Address
+import uk.gov.hmrc.carfregistration.models.requests.RegisterIndividualWithIdRequest
+import uk.gov.hmrc.carfregistration.models.responses.RegisterIndividualWithIdResponse
+import uk.gov.hmrc.carfregistration.services.RegistrationService
 
-class RegistrationControllerSpec extends SpecBase {}
+import scala.concurrent.Future
+
+class RegistrationControllerSpec extends SpecBase {
+
+  val mockService: RegistrationService       = mock[RegistrationService]
+  val testController: RegistrationController = new RegistrationController(cc, fakeAuthAction, mockService)
+
+  val testServiceResponseBody: JsValue = Json.toJson(
+    RegisterIndividualWithIdResponse(
+      safeId = "test-safe-id",
+      firstName = "testFName",
+      lastName = "testLName",
+      middleName = Some("testMName"),
+      address = Address(
+        addressLine1 = "TestLine1",
+        addressLine2 = Some("TestLine2"),
+        addressLine3 = Some("TestLine3"),
+        addressLine4 = Some("TestLine4"),
+        postalCode = Some("ABC 123"),
+        countryCode = "GB"
+      )
+    )
+  )
+
+  val testRequest: JsValue = Json.toJson(
+    RegisterIndividualWithIdRequest(
+      requiresNameMatch = true,
+      IDNumber = "123",
+      IDType = "testType",
+      dateOfBirth = "123",
+      firstName = "Katie",
+      lastName = "Long"
+    )
+  )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockService)
+  }
+
+  "RegistrationController" - {
+    "registerIndividualWithId" - {
+      "must return response from service" in {
+        when(mockService.returnResponse(any())).thenReturn(Ok(testServiceResponseBody))
+
+        val result = testController.registerIndividualWithId()(fakeRequestWithJsonBody(testRequest))
+
+        result.toString mustBe Future.successful(Ok(testServiceResponseBody)).toString
+      }
+      "must return bad request when the request is not valid" in {
+        val result = testController.registerIndividualWithId()(fakeRequestWithJsonBody(Json.toJson("invalid timmy")))
+
+        result.toString mustBe Future.successful(BadRequest("")).toString
+      }
+    }
+  }
+}

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -14,15 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.carfregistration.controllers
+package controllers
 
-import play.api.mvc.ControllerComponents
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import base.SpecBase
 
-import javax.inject.Inject
-
-class CarfController @Inject() (
-    cc: ControllerComponents
-) extends BackendController(cc):
-
-  def getDetails: Int = 5
+class RegistrationControllerSpec extends SpecBase {}


### PR DESCRIPTION
Backend changes for the first part of integrating our service with Stubbed endpoints!

We will construct the Request and Response models for sending/receiving the required data.

Test data will come through from the backend. We will get feedback on if this is working by entering as an Org, with a UTR on the Auth Wizard sign in. Our dummy data should display successfully on the "Is this your business?" page