### PR TITLE
CARF-389: Create FE/BE/Stubs for Individual without ID API Request

### DIFF
--- a/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
@@ -30,6 +30,11 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val registerWithIdBaseUrl: String      =
     s"$registerWithIdHost${config.get[String]("microservice.services.register-with-id.uri")}"
 
+  private val registerWithoutIdHost: String = servicesConfig.baseUrl("register-without-id")
+
+  val registerWithoutIdBaseUrl: String =
+    s"$registerWithoutIdHost${config.get[String]("microservice.services.register-without-id.uri")}"
+
   private val createSubscriptionHost: String = servicesConfig.baseUrl("create-subscription")
   val createSubscriptionBaseUrl: String      =
     s"$createSubscriptionHost${config.get[String]("microservice.services.create-subscription.uri")}"

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -128,7 +128,7 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
             Try(response.json.as[RegWithoutIdIndApiResponse]) match {
               case Success(data)      => Right(data)
               case Failure(exception) =>
-                logger.warn(
+                logger.error(
                   s"Error parsing response as RegWithoutIdIndApiResponse. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
                 )
                 Left(JsonValidationError)

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.carfregistration.connectors
 import cats.data.EitherT
 import com.google.inject.Inject
 import play.api.Logging
-import play.api.http.Status.{NOT_FOUND, OK}
+import play.api.http.Status.{NOT_FOUND, OK, UNPROCESSABLE_ENTITY}
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig
@@ -124,7 +124,7 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
         .withBody(Json.toJson(request))
         .execute[HttpResponse]
         .map {
-          case response if response.status == OK        =>
+          case response if response.status == OK                   =>
             Try(response.json.as[RegWithoutIdIndApiResponse]) match {
               case Success(data)      => Right(data)
               case Failure(exception) =>
@@ -133,13 +133,13 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
                 )
                 Left(JsonValidationError)
             }
-          case response if response.status == NOT_FOUND =>
+          case response if response.status == UNPROCESSABLE_ENTITY =>
             logger.warn(
               s"No match could be found for this individual (without ID): status code: ${response.status}, from endpoint: ${endpoint.toURI}"
             )
             Left(NotFoundError)
-          case response                                 =>
-            logger.warn(
+          case response                                            =>
+            logger.error(
               s"Unexpected response for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
             )
             Left(InternalServerError)

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig
 import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdIndApiRequest, RegWithIdOrgApiRequest, RegWithoutIdIndApiRequest}
-import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndApiResponse, RegWithIdOrgApiResponse, RegWithoutIdIndApiResponse}
+import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndApiResponse, RegWithIdOrgApiResponse, RegWithoutIdIndApiResponse, RegWithoutIdIndApiResponseWrapper}
 import uk.gov.hmrc.carfregistration.models.{ApiError, InternalServerError, JsonValidationError, NotFoundError}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -125,19 +125,19 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
         .execute[HttpResponse]
         .map {
           case response if response.status == OK                   =>
-            Try(response.json.as[RegWithoutIdIndApiResponse]) match {
-              case Success(data)      => Right(data)
+            Try(response.json.as[RegWithoutIdIndApiResponseWrapper]) match {
+              case Success(wrapper)   => Right(wrapper.regWithoutIdIndApiResponse)
               case Failure(exception) =>
                 logger.error(
-                  s"Error parsing response as RegWithoutIdIndApiResponse. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
+                  s"Error parsing response as RegWithoutIdIndApiResponseWrapper. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
                 )
                 Left(JsonValidationError)
             }
           case response if response.status == UNPROCESSABLE_ENTITY =>
             logger.warn(
-              s"No match could be found for this individual (without ID): status code: ${response.status}, from endpoint: ${endpoint.toURI}"
+              s"422 returned from backend for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
             )
-            Left(NotFoundError)
+            Left(InternalServerError)
           case response                                            =>
             logger.error(
               s"Unexpected response for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -20,10 +20,10 @@ import cats.data.EitherT
 import com.google.inject.Inject
 import play.api.Logging
 import play.api.http.Status.{NOT_FOUND, OK, UNPROCESSABLE_ENTITY}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdIndApiRequest, RegWithIdOrgApiRequest, RegWithoutIdIndApiRequest}
+import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdIndApiRequest, RegWithIdOrgApiRequest, RegWithoutIdIndApiRequest, RegWithoutIdIndApiRequestWrapper}
 import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndApiResponse, RegWithIdOrgApiResponse, RegWithoutIdIndApiResponse, RegWithoutIdIndApiResponseWrapper}
 import uk.gov.hmrc.carfregistration.models.{ApiError, InternalServerError, JsonValidationError, NotFoundError}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -49,6 +49,11 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
       hc: HeaderCarrier
   ): EitherT[Future, ApiError, RegWithIdOrgApiResponse] =
     registerOrganisationWithID(request, url"$backendBaseUrl")
+
+  def individualWithoutId(
+      request: RegWithoutIdIndApiRequest
+  )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
+    registerIndividualWithoutId(request, url"${config.registerWithoutIdBaseUrl}")
 
   private def registerOrganisationWithID(request: RegWithIdOrgApiRequest, endpoint: URL)(implicit
       hc: HeaderCarrier
@@ -109,40 +114,46 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
         }
     }
 
-  def individualWithoutId(
-      request: RegWithoutIdIndApiRequest
-  )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
-    registerIndividualWithoutId(request, url"${config.registerWithoutIdBaseUrl}")
-
   private def registerIndividualWithoutId(
       request: RegWithoutIdIndApiRequest,
       endpoint: URL
   )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
     EitherT {
+      val wrappedRequest = RegWithoutIdIndApiRequestWrapper(registerWithoutIDRequest = request)
+      logger.info(s"Sending wrapped request to stub: ${Json.prettyPrint(Json.toJson(wrappedRequest))}")
       http
         .post(endpoint)
-        .withBody(Json.toJson(request))
+        .withBody(Json.toJson(wrappedRequest))
         .execute[HttpResponse]
-        .map {
-          case response if response.status == OK                   =>
-            Try(response.json.as[RegWithoutIdIndApiResponseWrapper]) match {
-              case Success(wrapper)   => Right(wrapper.regWithoutIdIndApiResponse)
-              case Failure(exception) =>
-                logger.error(
-                  s"Error parsing response as RegWithoutIdIndApiResponseWrapper. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
-                )
-                Left(JsonValidationError)
-            }
-          case response if response.status == UNPROCESSABLE_ENTITY =>
-            logger.warn(
-              s"422 returned from backend for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
-            )
-            Left(InternalServerError)
-          case response                                            =>
-            logger.error(
-              s"Unexpected response for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
-            )
-            Left(InternalServerError)
+        .map { response =>
+          response.status match {
+            case OK =>
+              Try(response.json.as[RegWithoutIdIndApiResponseWrapper]) match {
+                case Success(wrapper) =>
+                  Right(wrapper.regWithoutIdIndApiResponse)
+                case Failure(_)       =>
+                  Try(response.json.as[RegWithoutIdIndApiResponse]) match {
+                    case Success(plainResponse) => Right(plainResponse)
+                    case Failure(exception)     =>
+                      logger.error(
+                        s"Error parsing response as RegWithoutIdIndApiResponse or wrapper. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
+                      )
+                      Left(JsonValidationError)
+                  }
+              }
+
+            case UNPROCESSABLE_ENTITY =>
+              logger.warn(
+                s"422 returned from backend for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
+              )
+              Left(InternalServerError)
+
+            case other =>
+              logger.error(
+                s"Unexpected response for individualWithoutId: status code: $other, from endpoint: ${endpoint.toURI}"
+              )
+              Left(InternalServerError)
+          }
         }
     }
 }

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -23,8 +23,8 @@ import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig
-import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdIndApiRequest, RegWithIdOrgApiRequest}
-import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndApiResponse, RegWithIdOrgApiResponse}
+import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdIndApiRequest, RegWithIdOrgApiRequest, RegWithoutIdIndApiRequest}
+import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndApiResponse, RegWithIdOrgApiResponse, RegWithoutIdIndApiResponse}
 import uk.gov.hmrc.carfregistration.models.{ApiError, InternalServerError, JsonValidationError, NotFoundError}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -109,4 +109,40 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
         }
     }
 
+  def individualWithoutId(
+      request: RegWithoutIdIndApiRequest
+  )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
+    registerIndividualWithoutId(request, url"${config.registerWithoutIdBaseUrl}")
+
+  private def registerIndividualWithoutId(
+      request: RegWithoutIdIndApiRequest,
+      endpoint: URL
+  )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
+    EitherT {
+      http
+        .post(endpoint)
+        .withBody(Json.toJson(request))
+        .execute[HttpResponse]
+        .map {
+          case response if response.status == OK        =>
+            Try(response.json.as[RegWithoutIdIndApiResponse]) match {
+              case Success(data)      => Right(data)
+              case Failure(exception) =>
+                logger.warn(
+                  s"Error parsing response as RegWithoutIdIndApiResponse. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
+                )
+                Left(JsonValidationError)
+            }
+          case response if response.status == NOT_FOUND =>
+            logger.warn(
+              s"No match could be found for this individual (without ID): status code: ${response.status}, from endpoint: ${endpoint.toURI}"
+            )
+            Left(NotFoundError)
+          case response                                 =>
+            logger.warn(
+              s"Unexpected response for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
+            )
+            Left(InternalServerError)
+        }
+    }
 }

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.carfregistration.connectors
 import cats.data.EitherT
 import com.google.inject.Inject
 import play.api.Logging
-import play.api.http.Status.{NOT_FOUND, OK, UNPROCESSABLE_ENTITY}
+import play.api.http.Status.{NOT_FOUND, OK, UNPROCESSABLE_ENTITY, SERVICE_UNAVAILABLE, METHOD_NOT_ALLOWED, BAD_REQUEST, FORBIDDEN,INTERNAL_SERVER_ERROR}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig
@@ -119,38 +119,73 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
       endpoint: URL
   )(implicit hc: HeaderCarrier): EitherT[Future, ApiError, RegWithoutIdIndApiResponse] =
     EitherT {
+
       val wrappedRequest = RegWithoutIdIndApiRequestWrapper(registerWithoutIDRequest = request)
-      logger.info(s"Sending wrapped request to stub: ${Json.prettyPrint(Json.toJson(wrappedRequest))}")
+
+      logger.debug(s"[RegistrationConnector] Calling individualWithoutId endpoint: ${endpoint.toURI}")
+
       http
         .post(endpoint)
         .withBody(Json.toJson(wrappedRequest))
         .execute[HttpResponse]
         .map { response =>
+
+          def extractSourceFaultDetail(resp: HttpResponse): Option[String] =
+            scala.util
+              .Try(resp.json)
+              .toOption
+              .flatMap(js => (js \ "errorDetail" \ "sourceFaultDetail" \ "detail").asOpt[Seq[String]])
+              .map(_.mkString(" | "))
+
           response.status match {
+
             case OK =>
               Try(response.json.as[RegWithoutIdIndApiResponseWrapper]) match {
+
                 case Success(wrapper) =>
                   Right(wrapper.regWithoutIdIndApiResponse)
-                case Failure(_)       =>
+
+                case Failure(_) =>
                   Try(response.json.as[RegWithoutIdIndApiResponse]) match {
-                    case Success(plainResponse) => Right(plainResponse)
-                    case Failure(exception)     =>
+
+                    case Success(plainResponse) =>
+                      Right(plainResponse)
+
+                    case Failure(exception) =>
                       logger.error(
-                        s"Error parsing response as RegWithoutIdIndApiResponse or wrapper. Endpoint: <${endpoint.toURI}> Exception: <${exception.getMessage}>"
+                        s"[RegistrationConnector] Failed to parse response for individualWithoutId from ${endpoint.toURI}. " +
+                          s"Exception: ${exception.getMessage}"
                       )
                       Left(JsonValidationError)
                   }
               }
 
-            case UNPROCESSABLE_ENTITY =>
+            case BAD_REQUEST | UNPROCESSABLE_ENTITY | INTERNAL_SERVER_ERROR | SERVICE_UNAVAILABLE =>
+              val detail = extractSourceFaultDetail(response)
+
+              detail match {
+                case Some(d) =>
+                  logger.warn(
+                    s"[RegistrationConnector] Upstream error ${response.status} from ${endpoint.toURI}. " +
+                      s"sourceFaultDetail.detail=[$d]"
+                  )
+                case None    =>
+                  logger.warn(
+                    s"[RegistrationConnector] Upstream error ${response.status} from ${endpoint.toURI}"
+                  )
+              }
+
+              Left(InternalServerError)
+
+            case FORBIDDEN | METHOD_NOT_ALLOWED =>
               logger.warn(
-                s"422 returned from backend for individualWithoutId: status code: ${response.status}, from endpoint: ${endpoint.toURI}"
+                s"[RegistrationConnector] HTTP ${response.status} returned from ${endpoint.toURI}"
               )
               Left(InternalServerError)
 
             case other =>
               logger.error(
-                s"Unexpected response for individualWithoutId: status code: $other, from endpoint: ${endpoint.toURI}"
+                s"[RegistrationConnector] Unexpected response $other from ${endpoint.toURI}"
               )
               Left(InternalServerError)
           }

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.carfregistration.connectors
 import cats.data.EitherT
 import com.google.inject.Inject
 import play.api.Logging
-import play.api.http.Status.{NOT_FOUND, OK, UNPROCESSABLE_ENTITY, SERVICE_UNAVAILABLE, METHOD_NOT_ALLOWED, BAD_REQUEST, FORBIDDEN,INTERNAL_SERVER_ERROR}
+import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, NOT_FOUND, OK, SERVICE_UNAVAILABLE, UNPROCESSABLE_ENTITY}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.carfregistration.config.AppConfig

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -21,8 +21,8 @@ import play.api.Logging
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.carfregistration.controllers.actions.AuthAction
-import uk.gov.hmrc.carfregistration.models.NotFoundError
-import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest}
+import uk.gov.hmrc.carfregistration.models.{JsonValidationError, MissingFieldsError, NotFoundError}
+import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest, RegWithoutIdIndFrontendRequest}
 import uk.gov.hmrc.carfregistration.services.RegistrationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -82,6 +82,31 @@ class RegistrationController @Inject() (
           Future.successful(NotFound("Could not find or create a business record for this organisation"))
         case Left(_)             =>
           Future.successful(InternalServerError("Unexpected error"))
+      }
+    }
+  }
+
+  def registerIndividualWithoutId(): Action[JsValue] = authorise(parse.json).async { implicit request =>
+    withJsonBody[RegWithoutIdIndFrontendRequest] { req =>
+      logger.debug(s"registerIndividualWithoutId request = \n-> $req")
+      service.registerIndWithoutId(req).map {
+        case Right(resp) => Ok(Json.toJson(resp))
+
+        case Left(NotFoundError) =>
+          logger.warn("registerIndividualWithoutId - NotFoundError")
+          InternalServerError("Unexpected error")
+
+        case Left(JsonValidationError) =>
+          logger.error("registerIndividualWithoutId - JsonValidationError")
+          InternalServerError("Unexpected error")
+
+        case Left(MissingFieldsError) =>
+          logger.error("registerIndividualWithoutId - MissingFieldsError")
+          InternalServerError("Unexpected error")
+
+        case Left(_) =>
+          logger.error("RegisterWithoutId unexpected error")
+          InternalServerError("Unexpected error")
       }
     }
   }

--- a/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/carfregistration/controllers/RegistrationController.scala
@@ -87,6 +87,12 @@ class RegistrationController @Inject() (
   }
 
   def registerIndividualWithoutId(): Action[JsValue] = authorise(parse.json).async { implicit request =>
+
+    lazy val unexpectedError = {
+      logger.error("registerIndividualWithoutId - unexpected error")
+      InternalServerError("Unexpected error")
+    }
+
     withJsonBody[RegWithoutIdIndFrontendRequest] { req =>
       logger.debug(s"registerIndividualWithoutId request = \n-> $req")
       service.registerIndWithoutId(req).map {
@@ -94,19 +100,11 @@ class RegistrationController @Inject() (
 
         case Left(NotFoundError) =>
           logger.warn("registerIndividualWithoutId - NotFoundError")
-          InternalServerError("Unexpected error")
+          unexpectedError
 
-        case Left(JsonValidationError) =>
-          logger.error("registerIndividualWithoutId - JsonValidationError")
-          InternalServerError("Unexpected error")
-
-        case Left(MissingFieldsError) =>
-          logger.error("registerIndividualWithoutId - MissingFieldsError")
-          InternalServerError("Unexpected error")
-
-        case Left(_) =>
-          logger.error("RegisterWithoutId unexpected error")
-          InternalServerError("Unexpected error")
+        case Left(JsonValidationError) => unexpectedError
+        case Left(MissingFieldsError)  => unexpectedError
+        case Left(_)                   => unexpectedError
       }
     }
   }

--- a/app/uk/gov/hmrc/carfregistration/models/requests/AddressDetailsFrontend.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/AddressDetailsFrontend.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class AddressDetailsFrontend(
+    addressLine1: String,
+    addressLine2: Option[String],
+    addressLine3: Option[String],
+    townOrCity: String,
+    postalCode: Option[String],
+    countryCode: String
+)
+
+object AddressDetailsFrontend {
+  implicit val format: OFormat[AddressDetailsFrontend] =
+    Json.format[AddressDetailsFrontend]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/ContactDetailsFrontend.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/ContactDetailsFrontend.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ContactDetailsFrontend(
+    emailAddress: String,
+    phoneNumber: Option[String]
+)
+
+object ContactDetailsFrontend {
+  implicit val format: OFormat[ContactDetailsFrontend] =
+    Json.format[ContactDetailsFrontend]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/IndividualDetailsWithoutId.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/IndividualDetailsWithoutId.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class IndividualDetailsWithoutId(
+    firstName: String,
+    lastName: String,
+    dateOfBirth: String
+)
+
+object IndividualDetailsWithoutId {
+  implicit val format: OFormat[IndividualDetailsWithoutId] = Json.format[IndividualDetailsWithoutId]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RegWithoutIdIndApiRequest(
+    requestCommon: RequestCommon,
+    requestDetail: RequestDetailIndividualWithoutId
+)
+
+object RegWithoutIdIndApiRequest {
+  implicit val format: OFormat[RegWithoutIdIndApiRequest] = Json.format[RegWithoutIdIndApiRequest]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
@@ -26,3 +26,11 @@ case class RegWithoutIdIndApiRequest(
 object RegWithoutIdIndApiRequest {
   implicit val format: OFormat[RegWithoutIdIndApiRequest] = Json.format[RegWithoutIdIndApiRequest]
 }
+
+case class RegWithoutIdIndApiRequestWrapper(
+    regWithoutIdIndApiRequest: RegWithoutIdIndApiRequest
+)
+
+object RegWithoutIdIndApiRequestWrapper {
+  implicit val format: OFormat[RegWithoutIdIndApiRequestWrapper] = Json.format[RegWithoutIdIndApiRequestWrapper]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndApiRequest.scala
@@ -28,7 +28,7 @@ object RegWithoutIdIndApiRequest {
 }
 
 case class RegWithoutIdIndApiRequestWrapper(
-    regWithoutIdIndApiRequest: RegWithoutIdIndApiRequest
+    registerWithoutIDRequest: RegWithoutIdIndApiRequest
 )
 
 object RegWithoutIdIndApiRequestWrapper {

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndFrontendRequest.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RegWithoutIdIndFrontendRequest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RegWithoutIdIndFrontendRequest(
+    firstName: String,
+    lastName: String,
+    dateOfBirth: String,
+    address: AddressDetailsFrontend,
+    contactDetails: ContactDetailsFrontend
+)
+
+object RegWithoutIdIndFrontendRequest {
+  implicit val format: OFormat[RegWithoutIdIndFrontendRequest] =
+    Json.format[RegWithoutIdIndFrontendRequest]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/requests/RequestDetailIndividualWithoutId.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/requests/RequestDetailIndividualWithoutId.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.requests
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RequestDetailIndividualWithoutId(
+    individual: IndividualDetailsWithoutId,
+    address: AddressDetailsFrontend,
+    contactDetails: ContactDetailsFrontend,
+    isAnAgent: Boolean = false,
+    isAGroup: Boolean = false
+)
+
+object RequestDetailIndividualWithoutId {
+  implicit val format: OFormat[RequestDetailIndividualWithoutId] = Json.format[RequestDetailIndividualWithoutId]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
@@ -23,3 +23,11 @@ case class RegWithoutIdIndApiResponse(responseCommon: ResponseCommon, responseDe
 object RegWithoutIdIndApiResponse {
   implicit val format: OFormat[RegWithoutIdIndApiResponse] = Json.format[RegWithoutIdIndApiResponse]
 }
+
+case class RegWithoutIdIndApiResponseWrapper(
+    regWithoutIdIndApiResponse: RegWithoutIdIndApiResponse
+)
+
+object RegWithoutIdIndApiResponseWrapper {
+  implicit val format: OFormat[RegWithoutIdIndApiResponseWrapper] = Json.format[RegWithoutIdIndApiResponseWrapper]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
@@ -18,7 +18,15 @@ package uk.gov.hmrc.carfregistration.models.responses
 
 import play.api.libs.json.{Json, OFormat}
 
-case class RegWithoutIdIndApiResponse(responseCommon: ResponseCommon, responseDetail: ResponseDetail)
+case class RegWithoutIdIndApiResponseDetail(
+    SAFEID: String
+)
+object RegWithoutIdIndApiResponseDetail {
+  implicit val format: OFormat[RegWithoutIdIndApiResponseDetail] =
+    Json.format[RegWithoutIdIndApiResponseDetail]
+}
+
+case class RegWithoutIdIndApiResponse(responseCommon: ResponseCommon, responseDetail: RegWithoutIdIndApiResponseDetail)
 
 object RegWithoutIdIndApiResponse {
   implicit val format: OFormat[RegWithoutIdIndApiResponse] = Json.format[RegWithoutIdIndApiResponse]

--- a/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndApiResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.responses
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RegWithoutIdIndApiResponse(responseCommon: ResponseCommon, responseDetail: ResponseDetail)
+
+object RegWithoutIdIndApiResponse {
+  implicit val format: OFormat[RegWithoutIdIndApiResponse] = Json.format[RegWithoutIdIndApiResponse]
+}

--- a/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndFrontendResponse.scala
+++ b/app/uk/gov/hmrc/carfregistration/models/responses/RegWithoutIdIndFrontendResponse.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration.models.responses
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RegWithoutIdIndFrontendResponse(
+    safeId: String
+)
+
+object RegWithoutIdIndFrontendResponse {
+  implicit val format: OFormat[RegWithoutIdIndFrontendResponse] = Json.format[RegWithoutIdIndFrontendResponse]
+
+  def apply(apiResponse: RegWithoutIdIndApiResponse): RegWithoutIdIndFrontendResponse =
+    RegWithoutIdIndFrontendResponse(
+      safeId = apiResponse.responseDetail.SAFEID
+    )
+}

--- a/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.carfregistration.services
 
 import uk.gov.hmrc.carfregistration.connectors.RegistrationConnector
 import uk.gov.hmrc.carfregistration.models.requests.*
-import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndFrontendResponse, RegWithIdOrgFrontendResponse}
+import uk.gov.hmrc.carfregistration.models.responses.{RegWithIdIndFrontendResponse, RegWithIdOrgFrontendResponse, RegWithoutIdIndFrontendResponse}
 import uk.gov.hmrc.carfregistration.models.{ApiError, UuidGen}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -93,4 +93,27 @@ class RegistrationService @Inject() (connector: RegistrationConnector, clock: Cl
         case Right(response) => RegWithIdOrgFrontendResponse.apply(response)
         case Left(error)     => Left(error)
       }
+
+  def registerIndWithoutId(
+      frontendRequest: RegWithoutIdIndFrontendRequest
+  )(implicit hc: HeaderCarrier): Future[Either[ApiError, RegWithoutIdIndFrontendResponse]] = {
+
+    val apiRequest = RegWithoutIdIndApiRequest(
+      requestCommon = RequestCommon("CARF", uuidGen, clock),
+      requestDetail = RequestDetailIndividualWithoutId(
+        individual = IndividualDetailsWithoutId(
+          firstName = frontendRequest.firstName,
+          lastName = frontendRequest.lastName,
+          dateOfBirth = frontendRequest.dateOfBirth
+        ),
+        address = frontendRequest.address,
+        contactDetails = frontendRequest.contactDetails
+      )
+    )
+
+    connector.individualWithoutId(apiRequest).value.map {
+      case Right(apiResponse) => Right(RegWithoutIdIndFrontendResponse(apiResponse))
+      case Left(error)        => Left(error)
+    }
+  }
 }

--- a/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
+++ b/app/uk/gov/hmrc/carfregistration/services/RegistrationService.scala
@@ -112,7 +112,7 @@ class RegistrationService @Inject() (connector: RegistrationConnector, clock: Cl
     )
 
     connector.individualWithoutId(apiRequest).value.map {
-      case Right(apiResponse) => Right(RegWithoutIdIndFrontendResponse(apiResponse))
+      case Right(apiResponse) => Right(RegWithoutIdIndFrontendResponse(apiResponse.responseDetail.SAFEID))
       case Left(error)        => Left(error)
     }
   }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,3 +6,5 @@ POST        /organisation/utr/user-entered         uk.gov.hmrc.carfregistration.
 POST        /organisation/utr/ct-auto-match        uk.gov.hmrc.carfregistration.controllers.RegistrationController.registerAutoMatchOrganisationWithId()
 
 POST        /subscription/subscribe                uk.gov.hmrc.carfregistration.controllers.SubscriptionController.createSubscription()
+
+POST        /individual-without-id                 uk.gov.hmrc.carfregistration.controllers.RegistrationController.registerIndividualWithoutId()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,6 +61,12 @@ microservice {
       port = 17010
       uri = /dac6/dct102b/v1
     }
+    register-without-id {
+      protocol = http
+      host = localhost
+      port = 17010
+      uri = /dac6/dprs0101/v1
+    }
     create-subscription {
       protocol = http
       host = localhost

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,6 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->         /                          prod.Routes
+->          /                                                                          prod.Routes
+
+POST        /register-for-cryptoasset-reporting/test-only/individual-without-id        uk.gov.hmrc.carfregistration.controllers.RegistrationController.registerIndividualWithoutId()

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,6 +10,4 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->          /                                                                          prod.Routes
-
-POST        /register-for-cryptoasset-reporting/test-only/individual-without-id        uk.gov.hmrc.carfregistration.controllers.RegistrationController.registerIndividualWithoutId()
+->        /        prod.Routes

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -194,19 +194,23 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
   )
 
   val testWithoutIdResponseJson: String =
-    """{
-      | "responseCommon": {
-      |   "status": "OK",
-      |   "processingDate": "2025-11-03"
-      | },
-      | "responseDetail": {
-      |   "SAFEID": "SAFE123456",
-      |   "address": {
-      |     "addressLine1": "123 Test Street",
-      |     "countryCode": "GB"
+    """
+      |{
+      | "regWithoutIdIndApiResponse": {
+      |   "responseCommon": {
+      |     "status": "OK",
+      |     "processingDate": "2025-11-03"
+      |   },
+      |   "responseDetail": {
+      |     "SAFEID": "SAFE123456",
+      |     "address": {
+      |       "addressLine1": "123 Test Street",
+      |       "countryCode": "GB"
+      |     }
       |   }
       | }
-      |}""".stripMargin
+      |}
+      |""".stripMargin
 
   val testWithoutIdResponseBody =
     RegWithoutIdIndApiResponse(
@@ -345,7 +349,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       )
 
       val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
-      result mustBe Left(NotFoundError)
+      result mustBe Left(InternalServerError)
     }
 
     "return InternalServerError for 500 response" in {

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -226,42 +226,6 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       )
     )
 
-  val expectedWithoutIdRequestJson = Json.parse(
-    """
-    {
-      "regWithoutIdIndApiRequest": {
-        "requestCommon": {
-          "acknowledgementReference": "test-Ref",
-          "receiptDate": "test-Date",
-          "regime": "CARF"
-        },
-        "requestDetail": {
-          "individual": {
-            "firstName": "John",
-            "lastName": "Doe",
-            "dateOfBirth": "1990-01-01"
-          },
-          "address": {
-            "addressLine1": "123 Test Street",
-            "addressLine2": "Flat 1",
-            "townOrCity": "France",
-            "postalCode": "75008",
-            "countryCode": "FR"
-          },
-          "contactDetails": {
-            "emailAddress": "john.doe@example.com",
-            "phoneNumber": "07123456789"
-          },
-          "isAnAgent": false,
-          "isAGroup": false
-        }
-      }
-    }
-  """
-  )
-
-
-
   "individualWithId" should {
     "successfully retrieve the api response" in {
       stubFor(
@@ -317,13 +281,42 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
   }
 
   "individualWithoutId" should {
-
-    val exactRequestJson = Json.prettyPrint(Json.toJson(testWithoutIdRequest))
+    
+    val expectedWithoutIdRequestJson: String =
+      """
+        |{
+        |  "requestCommon": {
+        |    "acknowledgementReference": "test-Ref",
+        |    "receiptDate": "test-Date",
+        |    "regime": "CARF"
+        |  },
+        |  "requestDetail": {
+        |    "individual": {
+        |      "firstName": "John",
+        |      "lastName": "Doe",
+        |      "dateOfBirth": "1990-01-01"
+        |    },
+        |    "address": {
+        |      "addressLine1": "123 Test Street",
+        |      "addressLine2": "Flat 1",
+        |      "townOrCity": "France",
+        |      "postalCode": "75008",
+        |      "countryCode": "FR"
+        |    },
+        |    "contactDetails": {
+        |      "emailAddress": "john.doe@example.com",
+        |      "phoneNumber": "07123456789"
+        |    },
+        |    "isAnAgent": false,
+        |    "isAGroup": false
+        |  }
+        |}
+        |""".stripMargin
 
     "successfully retrieve the api response" in {
       stubFor(
         post(urlPathMatching("/dac6/dprs0101/v1"))
-          .withRequestBody(equalToJson(exactRequestJson))
+          .withRequestBody(equalToJson(expectedWithoutIdRequestJson))
           .willReturn(
             aResponse()
               .withStatus(OK)

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlPathMatching, equalToJson}
 import itutil.ApplicationWithWiremock
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
@@ -113,7 +113,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     addressLine2 = Some("Flat 1"),
     addressLine3 = None,
     townOrCity = "France",
-    postalCode = Some("SW1A 1AA"),
+    postalCode = Some("75008"),
     countryCode = "FR"
   )
 
@@ -226,6 +226,41 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       )
     )
 
+  val expectedWithoutIdRequestJson = Json.parse(
+    """
+    {
+      "regWithoutIdIndApiRequest": {
+        "requestCommon": {
+          "acknowledgementReference": "test-Ref",
+          "receiptDate": "test-Date",
+          "regime": "CARF"
+        },
+        "requestDetail": {
+          "individual": {
+            "firstName": "John",
+            "lastName": "Doe",
+            "dateOfBirth": "1990-01-01"
+          },
+          "address": {
+            "addressLine1": "123 Test Street",
+            "addressLine2": "Flat 1",
+            "townOrCity": "France",
+            "postalCode": "75008",
+            "countryCode": "FR"
+          },
+          "contactDetails": {
+            "emailAddress": "john.doe@example.com",
+            "phoneNumber": "07123456789"
+          },
+          "isAnAgent": false,
+          "isAGroup": false
+        }
+      }
+    }
+  """
+  )
+
+
 
   "individualWithId" should {
     "successfully retrieve the api response" in {
@@ -283,10 +318,17 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
 
   "individualWithoutId" should {
 
+    val exactRequestJson = Json.prettyPrint(Json.toJson(testWithoutIdRequest))
+
     "successfully retrieve the api response" in {
       stubFor(
         post(urlPathMatching("/dac6/dprs0101/v1"))
-          .willReturn(aResponse().withStatus(OK).withBody(testWithoutIdResponseJson))
+          .withRequestBody(equalToJson(exactRequestJson))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(testWithoutIdResponseJson)
+          )
       )
 
       val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -196,37 +196,20 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
   val testWithoutIdResponseJson: String =
     """
       |{
-      | "regWithoutIdIndApiResponse": {
-      |   "responseCommon": {
-      |     "status": "OK",
-      |     "processingDate": "2025-11-03"
-      |   },
-      |   "responseDetail": {
-      |     "SAFEID": "SAFE123456",
-      |     "address": {
-      |       "addressLine1": "123 Test Street",
-      |       "countryCode": "GB"
-      |     }
-      |   }
-      | }
+      |  "responseCommon": {
+      |    "status": "OK"
+      |  },
+      |  "responseDetail": {
+      |    "SAFEID": "SAFE123456"
+      |  }
       |}
       |""".stripMargin
 
   val testWithoutIdResponseBody =
     RegWithoutIdIndApiResponse(
       responseCommon = ResponseCommon(status = "OK"),
-      responseDetail = ResponseDetail(
-        SAFEID = "SAFE123456",
-        address = AddressResponse(
-          addressLine1 = "123 Test Street",
-          addressLine2 = None,
-          addressLine3 = None,
-          addressLine4 = None,
-          postalCode = None,
-          countryCode = "GB"
-        ),
-        individual = None,
-        organisation = None
+      responseDetail = RegWithoutIdIndApiResponseDetail(
+        SAFEID = "SAFE123456"
       )
     )
 
@@ -288,39 +271,41 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
 
     val expectedWithoutIdRequestJson: String =
       """
-        |{
-        |  "requestCommon": {
-        |    "acknowledgementReference": "test-Ref",
-        |    "receiptDate": "test-Date",
-        |    "regime": "CARF"
-        |  },
-        |  "requestDetail": {
-        |    "individual": {
-        |      "firstName": "John",
-        |      "lastName": "Doe",
-        |      "dateOfBirth": "1990-01-01"
-        |    },
-        |    "address": {
-        |      "addressLine1": "123 Test Street",
-        |      "addressLine2": "Flat 1",
-        |      "townOrCity": "France",
-        |      "postalCode": "75008",
-        |      "countryCode": "FR"
-        |    },
-        |    "contactDetails": {
-        |      "emailAddress": "john.doe@example.com",
-        |      "phoneNumber": "07123456789"
-        |    },
-        |    "isAnAgent": false,
-        |    "isAGroup": false
-        |  }
-        |}
-        |""".stripMargin
+      {
+        "registerWithoutIDRequest": {
+          "requestCommon": {
+            "acknowledgementReference": "test-Ref",
+            "receiptDate": "test-Date",
+            "regime": "CARF"
+          },
+          "requestDetail": {
+            "individual": {
+              "firstName": "John",
+              "lastName": "Doe",
+              "dateOfBirth": "1990-01-01"
+            },
+            "address": {
+              "addressLine1": "123 Test Street",
+              "addressLine2": "Flat 1",
+              "townOrCity": "France",
+              "postalCode": "75008",
+              "countryCode": "FR"
+            },
+            "contactDetails": {
+              "emailAddress": "john.doe@example.com",
+              "phoneNumber": "07123456789"
+            },
+            "isAnAgent": false,
+            "isAGroup": false
+          }
+        }
+      }
+      """.stripMargin
 
     "successfully retrieve the api response" in {
       stubFor(
         post(urlPathMatching("/dac6/dprs0101/v1"))
-          .withRequestBody(equalToJson(expectedWithoutIdRequestJson))
+          .withRequestBody(equalToJson(expectedWithoutIdRequestJson, true , true))
           .willReturn(
             aResponse()
               .withStatus(OK)
@@ -329,7 +314,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       )
 
       val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
-      result mustBe Right(testWithoutIdResponseBody)
+      result mustBe Right(RegWithoutIdIndApiResponse(ResponseCommon("OK"), RegWithoutIdIndApiResponseDetail("SAFE123456")))
     }
 
     "return JsonValidationError if invalid JSON returned" in {

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -21,7 +21,7 @@ import itutil.ApplicationWithWiremock
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK}
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK, UNPROCESSABLE_ENTITY}
 import play.api.libs.json.Json
 import uk.gov.hmrc.carfregistration.connectors.RegistrationConnector
 import uk.gov.hmrc.carfregistration.models.requests.*
@@ -338,10 +338,10 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       result mustBe Left(JsonValidationError)
     }
 
-    "return NotFoundError if 404 returned" in {
+    "return NotFoundError if 422 returned" in {
       stubFor(
         post(urlPathMatching("/dac6/dprs0101/v1"))
-          .willReturn(aResponse().withStatus(NOT_FOUND))
+          .willReturn(aResponse().withStatus(UNPROCESSABLE_ENTITY))
       )
 
       val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -327,7 +327,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       result mustBe Left(JsonValidationError)
     }
 
-    "return NotFoundError if 422 returned" in {
+    "return InternalServerError if 422 returned" in {
       stubFor(
         post(urlPathMatching("/dac6/dprs0101/v1"))
           .willReturn(aResponse().withStatus(UNPROCESSABLE_ENTITY))

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -108,6 +108,20 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     countryCode = "GB"
   )
 
+  private val testAddressFrontend = AddressDetailsFrontend(
+    addressLine1 = "123 Test Street",
+    addressLine2 = Some("Flat 1"),
+    addressLine3 = None,
+    townOrCity = "France",
+    postalCode = Some("SW1A 1AA"),
+    countryCode = "FR"
+  )
+
+  private val testContactDetails = ContactDetailsFrontend(
+    emailAddress = "john.doe@example.com",
+    phoneNumber = Some("07123456789")
+  )
+  
   val testUserEnteredOrgWithUtrFrontendRequest = RegWithIdUserEntryOrgFrontendRequest(
     requiresNameMatch = false,
     IDType = "UTR",
@@ -162,6 +176,57 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     )
   )
 
+  val testWithoutIdRequest = RegWithoutIdIndApiRequest(
+    requestCommon = RequestCommon(
+      acknowledgementReference = "test-Ref",
+      receiptDate = "test-Date",
+      regime = "CARF"
+    ),
+    requestDetail = RequestDetailIndividualWithoutId(
+      individual = IndividualDetailsWithoutId(
+        firstName = "John",
+        lastName = "Doe",
+        dateOfBirth = "1990-01-01"
+      ),
+      address = testAddressFrontend,
+      contactDetails = testContactDetails
+    )
+  )
+
+  val testWithoutIdResponseJson: String =
+    """{
+      | "responseCommon": {
+      |   "status": "OK",
+      |   "processingDate": "2025-11-03"
+      | },
+      | "responseDetail": {
+      |   "SAFEID": "SAFE123456",
+      |   "address": {
+      |     "addressLine1": "123 Test Street",
+      |     "countryCode": "GB"
+      |   }
+      | }
+      |}""".stripMargin
+
+  val testWithoutIdResponseBody =
+    RegWithoutIdIndApiResponse(
+      responseCommon = ResponseCommon(status = "OK"),
+      responseDetail = ResponseDetail(
+        SAFEID = "SAFE123456",
+        address = AddressResponse(
+          addressLine1 = "123 Test Street",
+          addressLine2 = None,
+          addressLine3 = None,
+          addressLine4 = None,
+          postalCode = None,
+          countryCode = "GB"
+        ),
+        individual = None,
+        organisation = None
+      )
+    )
+
+
   "individualWithId" should {
     "successfully retrieve the api response" in {
       stubFor(
@@ -212,6 +277,49 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
           )
       )
       val result = connector.individualWithId(testRequest).value.futureValue
+      result mustBe Left(InternalServerError)
+    }
+  }
+
+  "individualWithoutId" should {
+
+    "successfully retrieve the api response" in {
+      stubFor(
+        post(urlPathMatching("/dac6/dprs0101/v1"))
+          .willReturn(aResponse().withStatus(OK).withBody(testWithoutIdResponseJson))
+      )
+
+      val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
+      result mustBe Right(testWithoutIdResponseBody)
+    }
+
+    "return JsonValidationError if invalid JSON returned" in {
+      stubFor(
+        post(urlPathMatching("/dac6/dprs0101/v1"))
+          .willReturn(aResponse().withStatus(OK).withBody("invalid-json"))
+      )
+
+      val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
+      result mustBe Left(JsonValidationError)
+    }
+
+    "return NotFoundError if 404 returned" in {
+      stubFor(
+        post(urlPathMatching("/dac6/dprs0101/v1"))
+          .willReturn(aResponse().withStatus(NOT_FOUND))
+      )
+
+      val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
+      result mustBe Left(NotFoundError)
+    }
+
+    "return InternalServerError for 500 response" in {
+      stubFor(
+        post(urlPathMatching("/dac6/dprs0101/v1"))
+          .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
+      )
+
+      val result = connector.individualWithoutId(testWithoutIdRequest).value.futureValue
       result mustBe Left(InternalServerError)
     }
   }

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlPathMatching, equalToJson}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalToJson, post, stubFor, urlPathMatching}
 import itutil.ApplicationWithWiremock
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
@@ -121,7 +121,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     emailAddress = "john.doe@example.com",
     phoneNumber = Some("07123456789")
   )
-  
+
   val testUserEnteredOrgWithUtrFrontendRequest = RegWithIdUserEntryOrgFrontendRequest(
     requiresNameMatch = false,
     IDType = "UTR",
@@ -281,7 +281,7 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
   }
 
   "individualWithoutId" should {
-    
+
     val expectedWithoutIdRequestJson: String =
       """
         |{

--- a/it/test/itutil/ApplicationWithWiremock.scala
+++ b/it/test/itutil/ApplicationWithWiremock.scala
@@ -38,7 +38,7 @@ trait ApplicationWithWiremock
       "microservice.services.register-with-id.host"    -> WireMockConstants.stubHost,
       "microservice.services.register-with-id.port"    -> WireMockConstants.stubPort,
       "microservice.services.create-subscription.host" -> WireMockConstants.stubHost,
-      "microservice.services.create-subscription.port" -> WireMockConstants.stubPort
+      "microservice.services.create-subscription.port" -> WireMockConstants.stubPort,
       "microservice.services.auth.host"                -> WireMockConstants.stubHost,
       "microservice.services.auth.port"                -> WireMockConstants.stubPort,
       "microservice.services.register-with-id.host"    -> WireMockConstants.stubHost,

--- a/it/test/itutil/ApplicationWithWiremock.scala
+++ b/it/test/itutil/ApplicationWithWiremock.scala
@@ -39,6 +39,12 @@ trait ApplicationWithWiremock
       "microservice.services.register-with-id.port"    -> WireMockConstants.stubPort,
       "microservice.services.create-subscription.host" -> WireMockConstants.stubHost,
       "microservice.services.create-subscription.port" -> WireMockConstants.stubPort
+      "microservice.services.auth.host"                -> WireMockConstants.stubHost,
+      "microservice.services.auth.port"                -> WireMockConstants.stubPort,
+      "microservice.services.register-with-id.host"    -> WireMockConstants.stubHost,
+      "microservice.services.register-with-id.port"    -> WireMockConstants.stubPort,
+      "microservice.services.register-without-id.host" -> WireMockConstants.stubHost,
+      "microservice.services.register-without-id.port" -> WireMockConstants.stubPort
     )
 
   override lazy val app: Application = new GuiceApplicationBuilder()

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -270,26 +270,30 @@ class RegistrationControllerSpec extends SpecBase {
 
     "registerIndividualWithoutId" - {
 
-      val frontendRequest = RegWithoutIdIndFrontendRequest(
-        firstName = "John",
-        lastName = "Doe",
-        dateOfBirth = "1990-01-01",
-        address = AddressDetailsFrontend(
-          addressLine1 = "123 Test Street",
-          addressLine2 = Some("Flat 1"),
-          addressLine3 = None,
-          townOrCity = "France",
-          postalCode = Some("SW1A 1AA"),
-          countryCode = "FR"
-        ),
-        contactDetails = ContactDetailsFrontend(
-          emailAddress = "john.doe@example.com",
-          phoneNumber = Some("07123456789")
-        )
-      )
+      val frontendRequestJsonStr: String =
+        """
+          |{
+          |  "firstName": "John",
+          |  "lastName": "Doe",
+          |  "dateOfBirth": "1990-01-01",
+          |  "address": {
+          |    "addressLine1": "123 Test Street",
+          |    "addressLine2": "Flat 1",
+          |    "addressLine3": null,
+          |    "townOrCity": "France",
+          |    "postalCode": "SW1A 1AA",
+          |    "countryCode": "FR"
+          |  },
+          |  "contactDetails": {
+          |    "emailAddress": "john.doe@example.com",
+          |    "phoneNumber": "07123456789"
+          |  }
+          |}
+          |""".stripMargin
 
-      val request = FakeRequest(POST, "/individual-without-id")
-        .withJsonBody(Json.toJson(frontendRequest))
+      val frontendRequestJson: JsValue = Json.parse(frontendRequestJsonStr)
+
+      val request = fakeRequestWithJsonBody(frontendRequestJson)
 
       "must return OK when the service returns a successful response" in {
         val apiResponse =
@@ -300,9 +304,8 @@ class RegistrationControllerSpec extends SpecBase {
         when(mockService.registerIndWithoutId(any())(any()))
           .thenReturn(Future.successful(Right(apiResponse)))
 
-        val result = testController.registerIndividualWithoutId()(
-          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
-        )
+        val result = testController.registerIndividualWithoutId()(request)
+
         status(result)        mustBe OK
         contentAsJson(result) mustBe Json.toJson(apiResponse)
       }
@@ -311,9 +314,7 @@ class RegistrationControllerSpec extends SpecBase {
         when(mockService.registerIndWithoutId(any())(any()))
           .thenReturn(Future.successful(Left(NotFoundError)))
 
-        val result = testController.registerIndividualWithoutId()(
-          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
-        )
+        val result = testController.registerIndividualWithoutId()(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
       }
@@ -322,9 +323,7 @@ class RegistrationControllerSpec extends SpecBase {
         when(mockService.registerIndWithoutId(any())(any()))
           .thenReturn(Future.successful(Left(InternalServerError)))
 
-        val result = testController.registerIndividualWithoutId()(
-          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
-        )
+        val result = testController.registerIndividualWithoutId()(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
       }
@@ -333,9 +332,7 @@ class RegistrationControllerSpec extends SpecBase {
         when(mockService.registerIndWithoutId(any())(any()))
           .thenReturn(Future.successful(Left(JsonValidationError)))
 
-        val result = testController.registerIndividualWithoutId()(
-          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
-        )
+        val result = testController.registerIndividualWithoutId()(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
       }

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -22,12 +22,15 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND, OK}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results.BadRequest
-import play.api.test.Helpers.{contentAsJson, contentAsString, status}
+import play.api.test.Helpers._
 import uk.gov.hmrc.carfregistration.controllers.RegistrationController
-import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest}
-import uk.gov.hmrc.carfregistration.models.responses.{AddressResponse, RegWithIdIndFrontendResponse, RegWithIdOrgFrontendResponse}
-import uk.gov.hmrc.carfregistration.models.{InternalServerError, NotFoundError}
+import uk.gov.hmrc.carfregistration.models.requests.{AddressDetailsFrontend, ContactDetailsFrontend, RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest, RegWithoutIdIndFrontendRequest}
+import uk.gov.hmrc.carfregistration.models.responses.{AddressResponse, RegWithIdIndFrontendResponse, RegWithIdOrgFrontendResponse, RegWithoutIdIndFrontendResponse}
+import uk.gov.hmrc.carfregistration.models.{InternalServerError, JsonValidationError, NotFoundError}
 import uk.gov.hmrc.carfregistration.services.RegistrationService
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
 
 import scala.concurrent.Future
 
@@ -262,6 +265,79 @@ class RegistrationControllerSpec extends SpecBase {
         )
 
         result.toString mustBe Future.successful(BadRequest("")).toString
+      }
+    }
+
+    "registerIndividualWithoutId" - {
+
+      val frontendRequest = RegWithoutIdIndFrontendRequest(
+        firstName = "John",
+        lastName = "Doe",
+        dateOfBirth = "1990-01-01",
+        address = AddressDetailsFrontend(
+          addressLine1 = "123 Test Street",
+          addressLine2 = Some("Flat 1"),
+          addressLine3 = None,
+          townOrCity = "France",
+          postalCode = Some("SW1A 1AA"),
+          countryCode = "FR"
+        ),
+        contactDetails = ContactDetailsFrontend(
+          emailAddress = "john.doe@example.com",
+          phoneNumber = Some("07123456789")
+        )
+      )
+
+      val request = FakeRequest(POST, "/individual-without-id")
+        .withJsonBody(Json.toJson(frontendRequest))
+
+      "must return OK when the service returns a successful response" in {
+        val apiResponse =
+          RegWithoutIdIndFrontendResponse(
+            safeId = "SAFE123456"
+          )
+
+        when(mockService.registerIndWithoutId(any())(any()))
+          .thenReturn(Future.successful(Right(apiResponse)))
+
+        val result = testController.registerIndividualWithoutId()(
+          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
+        )
+        status(result)        mustBe OK
+        contentAsJson(result) mustBe Json.toJson(apiResponse)
+      }
+
+      "must return internal server error when the service returns NotFoundError" in {
+        when(mockService.registerIndWithoutId(any())(any()))
+          .thenReturn(Future.successful(Left(NotFoundError)))
+
+        val result = testController.registerIndividualWithoutId()(
+          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
+        )
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+      }
+
+      "must return internal server error when the service returns InternalServerError" in {
+        when(mockService.registerIndWithoutId(any())(any()))
+          .thenReturn(Future.successful(Left(InternalServerError)))
+
+        val result = testController.registerIndividualWithoutId()(
+          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
+        )
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+      }
+
+      "must return internal server error when the service returns JsonValidationError" in {
+        when(mockService.registerIndWithoutId(any())(any()))
+          .thenReturn(Future.successful(Left(JsonValidationError)))
+
+        val result = testController.registerIndividualWithoutId()(
+          fakeRequestWithJsonBody(Json.toJson(frontendRequest))
+        )
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
       }
     }
   }

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -306,17 +306,7 @@ class RegistrationServiceSpec extends SpecBase {
         val apiResponse = RegWithoutIdIndApiResponse(
           responseCommon = ResponseCommon(status = "OK"),
           responseDetail = RegWithoutIdIndApiResponseDetail(
-            SAFEID = "SAFE123456",
-            address = AddressResponse(
-              addressLine1 = "123 Test Street",
-              addressLine2 = Some("Flat 1"),
-              addressLine3 = None,
-              addressLine4 = None,
-              postalCode = Some("SW1A 1AA"),
-              countryCode = "FR"
-            ),
-            individual = None,
-            organisation = None
+            SAFEID = "SAFE123456"
           )
         )
 
@@ -325,7 +315,7 @@ class RegistrationServiceSpec extends SpecBase {
 
         val result = testService.registerIndWithoutId(frontendRequest).futureValue
 
-        result shouldBe Right(RegWithoutIdIndFrontendResponse(apiResponse))
+        result mustBe Right(RegWithoutIdIndFrontendResponse("SAFE123456"))
       }
 
       "return error when connector returns an error" in {

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -305,7 +305,7 @@ class RegistrationServiceSpec extends SpecBase {
 
         val apiResponse = RegWithoutIdIndApiResponse(
           responseCommon = ResponseCommon(status = "OK"),
-          responseDetail = ResponseDetail(
+          responseDetail = RegWithoutIdIndApiResponseDetail(
             SAFEID = "SAFE123456",
             address = AddressResponse(
               addressLine1 = "123 Test Street",
@@ -325,7 +325,7 @@ class RegistrationServiceSpec extends SpecBase {
 
         val result = testService.registerIndWithoutId(frontendRequest).futureValue
 
-        result mustBe Right(RegWithoutIdIndFrontendResponse(apiResponse))
+        result shouldBe Right(RegWithoutIdIndFrontendResponse(apiResponse))
       }
 
       "return error when connector returns an error" in {

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -22,10 +22,10 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import uk.gov.hmrc.carfregistration.connectors.RegistrationConnector
 import uk.gov.hmrc.carfregistration.models.*
-import uk.gov.hmrc.carfregistration.models.requests.{RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest}
+import uk.gov.hmrc.carfregistration.models.requests.{AddressDetailsFrontend, ContactDetailsFrontend, RegWithIdAutoMatchOrgFrontendRequest, RegWithIdUserEntryOrgFrontendRequest, RegWithNinoIndFrontendRequest, RegWithUtrIndFrontendRequest, RegWithoutIdIndFrontendRequest}
 import uk.gov.hmrc.carfregistration.models.responses.*
 import uk.gov.hmrc.carfregistration.services.RegistrationService
-
+import org.scalatest.wordspec.AnyWordSpec
 import java.util.UUID
 import scala.concurrent.Future
 
@@ -128,6 +128,24 @@ class RegistrationServiceSpec extends SpecBase {
     organisationName = "AutoMatch Ltd",
     code = Some("0002"),
     address = testAddressResponse
+  )
+
+  val frontendRequest = RegWithoutIdIndFrontendRequest(
+    firstName = "John",
+    lastName = "Doe",
+    dateOfBirth = "1990-01-01",
+    address = AddressDetailsFrontend(
+      addressLine1 = "123 Test Street",
+      addressLine2 = Some("Flat 1"),
+      addressLine3 = None,
+      townOrCity = "France",
+      postalCode = Some("SW1A 1AA"),
+      countryCode = "FR"
+    ),
+    contactDetails = ContactDetailsFrontend(
+      emailAddress = "john.doe@example.com",
+      phoneNumber = Some("07123456789")
+    )
   )
 
   override def beforeEach(): Unit = {
@@ -277,6 +295,62 @@ class RegistrationServiceSpec extends SpecBase {
         val result =
           testService.registerAutoMatchOrgWithId(testAutoMatchOrgWithUtrFrontendRequest).futureValue
 
+        result mustBe Left(JsonValidationError)
+      }
+    }
+
+    "registerIndWithoutId" - {
+
+      "must return success frontend response when the connector returns a successful response" in {
+
+        val apiResponse = RegWithoutIdIndApiResponse(
+          responseCommon = ResponseCommon(status = "OK"),
+          responseDetail = ResponseDetail(
+            SAFEID = "SAFE123456",
+            address = AddressResponse(
+              addressLine1 = "123 Test Street",
+              addressLine2 = Some("Flat 1"),
+              addressLine3 = None,
+              addressLine4 = None,
+              postalCode = Some("SW1A 1AA"),
+              countryCode = "FR"
+            ),
+            individual = None,
+            organisation = None
+          )
+        )
+
+        when(mockConnector.individualWithoutId(any())(any()))
+          .thenReturn(EitherT.rightT[Future, ApiError](apiResponse))
+
+        val result = testService.registerIndWithoutId(frontendRequest).futureValue
+
+        result mustBe Right(RegWithoutIdIndFrontendResponse(apiResponse))
+      }
+
+      "return error when connector returns an error" in {
+
+        when(mockConnector.individualWithoutId(any())(any()))
+          .thenReturn(EitherT.leftT[Future, RegWithoutIdIndApiResponse](NotFoundError))
+
+        val result = testService.registerIndWithoutId(frontendRequest).futureValue
+
+        result mustBe Left(NotFoundError)
+      }
+
+      "must return an internal server error when the connector returns an internal server error" in {
+        when(mockConnector.individualWithoutId(any())(any()))
+          .thenReturn(EitherT.leftT[Future, RegWithoutIdIndApiResponse](InternalServerError))
+
+        val result = testService.registerIndWithoutId(frontendRequest).futureValue
+        result mustBe Left(InternalServerError)
+      }
+
+      "must return a json validation error when the connector returns json validation error" in {
+        when(mockConnector.individualWithoutId(any())(any()))
+          .thenReturn(EitherT.leftT[Future, RegWithoutIdIndApiResponse](JsonValidationError))
+
+        val result = testService.registerIndWithoutId(frontendRequest).futureValue
         result mustBe Left(JsonValidationError)
       }
     }

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -139,7 +139,7 @@ class RegistrationServiceSpec extends SpecBase {
       addressLine2 = Some("Flat 1"),
       addressLine3 = None,
       townOrCity = "France",
-      postalCode = Some("SW1A 1AA"),
+      postalCode = Some("75008"),
       countryCode = "FR"
     ),
     contactDetails = ContactDetailsFrontend(


### PR DESCRIPTION
Add Register Individual Without ID endpoint

- Added registerIndWithoutId method to RegistrationService
- Added individualWithoutId method to RegistrationConnector
- Created RegWithoutIdIndFrontendRequest model
- Created RegWithoutIdIndApiRequest and supporting request models
- Created RegWithoutIdIndApiResponse model
- Created RegWithoutIdIndFrontendResponse (returns safeId only)
- Added /individual-without-id POST route
- Implemented 500 handling for non-200 backend responses
- Added/updated unit tests