### PR TITLE
[CARF-423] Add required headers for registration calls, including authorization

### DIFF
--- a/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/carfregistration/config/AppConfig.scala
@@ -26,6 +26,12 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
 
   val appName: String = config.get[String]("appName")
 
+  val bearerToken: String => String =
+    (serviceName: String) => config.get[String](s"microservice.services.$serviceName.bearer-token")
+
+  val environment: String => String =
+    (serviceName: String) => config.get[String](s"microservice.services.$serviceName.environment")
+
   private val registerWithIdHost: String = servicesConfig.baseUrl("register-with-id")
   val registerWithIdBaseUrl: String      =
     s"$registerWithIdHost${config.get[String]("microservice.services.register-with-id.uri")}"
@@ -36,5 +42,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
     s"$registerWithoutIdHost${config.get[String]("microservice.services.register-without-id.uri")}"
 
   private val createSubscriptionHost: String = servicesConfig.baseUrl("create-subscription")
-  val createSubscriptionBaseUrl: String      =
+
+  val createSubscriptionBaseUrl: String =
     s"$createSubscriptionHost${config.get[String]("microservice.services.create-subscription.uri")}"

--- a/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/RegistrationConnector.scala
@@ -58,6 +58,7 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
       http
         .post(endpoint)
         .withBody(Json.toJson(request))
+        .setHeader(additionalHeaders(config, "register-with-id"): _*)
         .execute[HttpResponse]
         .map { response =>
           response.status match {
@@ -94,6 +95,7 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
       http
         .post(endpoint)
         .withBody(Json.toJson(request))
+        .setHeader(additionalHeaders(config, "register-with-id"): _*)
         .execute[HttpResponse]
         .map { response =>
           response.status match {
@@ -131,6 +133,7 @@ class RegistrationConnector @Inject() (val config: AppConfig, val http: HttpClie
       http
         .post(endpoint)
         .withBody(Json.toJson(request))
+        .setHeader(additionalHeaders(config, "register-without-id"): _*)
         .execute[HttpResponse]
         .map { response =>
           response.status match {

--- a/app/uk/gov/hmrc/carfregistration/connectors/package.scala
+++ b/app/uk/gov/hmrc/carfregistration/connectors/package.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.carfregistration
+
+import uk.gov.hmrc.carfregistration.config.AppConfig
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HeaderNames}
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+package object connectors {
+
+  private lazy val stripSession: String => String = (input: String) => input.replace("session-", "")
+
+  private[connectors] def additionalHeaders(
+      config: AppConfig,
+      serviceName: String
+  )(implicit headerCarrier: HeaderCarrier): Seq[(String, String)] = {
+    val authorizationHeaderCarrier = headerCarrier
+      .copy(authorization = Some(Authorization(s"Bearer ${config.bearerToken(serviceName)}")))
+
+    authorizationHeaderCarrier.headers(Seq(HeaderNames.authorisation)) ++ addHeaders(
+      config.environment(serviceName)
+    )
+  }
+
+  private def addHeaders(
+      eisEnvironment: String
+  )(implicit headerCarrier: HeaderCarrier): Seq[(String, String)] = {
+
+    // HTTP-date format defined by RFC 7231 e.g. Fri, 01 Aug 2020 15:51:38 GMT+1
+    val formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss O")
+
+    Seq(
+      "x-forwarded-host"  -> "mdtp",
+      "date"              -> ZonedDateTime.now().format(formatter),
+      "x-correlation-id"  -> UUID.randomUUID().toString,
+      "x-conversation-id" -> {
+        headerCarrier.sessionId
+          .map(s => stripSession(s.value))
+          .getOrElse(UUID.randomUUID().toString)
+      },
+      "content-type"      -> "application/json",
+      "accept"            -> "application/json",
+      "Environment"       -> eisEnvironment
+    )
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,12 +60,16 @@ microservice {
       host = localhost
       port = 17010
       uri = /dac6/dprs0102/v1
+      bearer-token = fakeToken
+      environment = local
     }
     register-without-id {
       protocol = http
       host = localhost
       port = 17010
       uri = /dac6/dprs0101/v1
+      bearer-token = fakeToken
+      environment = local
     }
     create-subscription {
       protocol = http

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -668,8 +668,8 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     val applicationJson = "application/json"
 
     builder
-      .withHeader("x-forwarded-host", matching(".*"))
-      .withHeader("date", matching(".*"))
+      .withHeader("x-forwarded-host", matching("mdtp"))
+      .withHeader("date", matching("^[A-Z][a-z]{2},\\s\\d{2}\\s[A-Z][a-z]{2}\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s[A-Z]{3,4}([+-]\\d{1,2})?$"))
       .withHeader("x-correlation-id", matching(uuidRegex.toString()))
       .withHeader("x-conversation-id", matching(uuidRegex.toString()))
       .withHeader("content-type", matching(applicationJson))

--- a/it/test/connectors/RegistrationConnectorISpec.scala
+++ b/it/test/connectors/RegistrationConnectorISpec.scala
@@ -16,6 +16,7 @@
 
 package connectors
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import itutil.ApplicationWithWiremock
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -254,9 +255,14 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
     )
 
   "individualWithId" should {
-    "successfully retrieve the api response" in {
-      stubFor(
+    "successfully retrieve the api response and ensure required headers are present in request" in {
+
+      val mappingBuilder = addMatchHeaders(
         post(urlPathMatching("/dac6/dprs0102/v1"))
+      )
+
+      stubFor(
+        mappingBuilder
           .willReturn(
             aResponse()
               .withStatus(OK)
@@ -412,9 +418,14 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
           }
           """.stripMargin
 
-    "successfully retrieve the api response for ind without id request" in {
-      stubFor(
+    "successfully retrieve the api response for ind without id request and ensure required headers are present" in {
+
+      val mappingBuilder = addMatchHeaders(
         post(urlPathMatching("/dac6/dprs0101/v1"))
+      )
+
+      stubFor(
+        mappingBuilder
           .withRequestBody(equalToJson(expectedIndWithoutIdRequestJson, true, true))
           .willReturn(
             aResponse()
@@ -431,9 +442,14 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       )
     }
 
-    "successfully retrieve the api response for org without id request" in {
-      stubFor(
+    "successfully retrieve the api response for org without id request and ensure required headers are present" in {
+
+      val mappingBuilder = addMatchHeaders(
         post(urlPathMatching("/dac6/dprs0101/v1"))
+      )
+
+      stubFor(
+        mappingBuilder
           .withRequestBody(equalToJson(expectedOrgWithoutIdRequestJson, true, true))
           .willReturn(
             aResponse()
@@ -644,5 +660,20 @@ class RegistrationConnectorISpec extends ApplicationWithWiremock with ScalaFutur
       val result = connector.individualWithId(testRequest).value.futureValue
       result mustBe Left(InternalServerError)
     }
+  }
+
+  def addMatchHeaders(builder: MappingBuilder): MappingBuilder = {
+
+    val uuidRegex = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".r
+    val applicationJson = "application/json"
+
+    builder
+      .withHeader("x-forwarded-host", matching(".*"))
+      .withHeader("date", matching(".*"))
+      .withHeader("x-correlation-id", matching(uuidRegex.toString()))
+      .withHeader("x-conversation-id", matching(uuidRegex.toString()))
+      .withHeader("content-type", matching(applicationJson))
+      .withHeader("accept", matching(applicationJson))
+      .withHeader("Environment", matching("local"))
   }
 }


### PR DESCRIPTION
Add the following headers to the registration with & withoutId endpoints:

- x-forwarded-host
- date      
- x-correlation-id
- x-conversation-id
- content-type 
- accept
- Environment